### PR TITLE
The API uses units of mireds for color temperature.

### DIFF
--- a/resources/lights/README.md
+++ b/resources/lights/README.md
@@ -9,4 +9,4 @@
 ## Considerations
 (*) Attempting to set a light's brightness to a low value like `2` may not do anything.
 
-(**) The 'Control Center' UI only allows color temperature changes from 2900K - 7000K in 50K increments. To convert the values used by the API to Kelvin (like it is displayed in the Elgato application), divide by 0.05 (e.g. 143 / 0.05 = 2860 ≈ 2900K). To covert from Kelvin to API values, multiply by 0.05 (e.g. 7000K ≈ 6880 * 0.05 = 344)
+(**) The color temperature in the API is expressed in units of mired. The 'Control Center' UI only allows color temperature changes from 2900K - 7000K in 50K increments. To convert from Kelvins to mireds, divide 1,000,000 by degrees Kelvin, (e.g. 1,000,000 / 7000K ≈ 143). To convert from mireds to Kelvin, divide 1,000,000 by mireds. (e.g., 2900K ≈ 1,000,000 / 344).


### PR DESCRIPTION
The documentation is updated to correct the units used for color temperature in the API. Mireds are described here:

https://en.wikipedia.org/wiki/Mired

Multiplying and dividing by 0.05 is inverted, first of all, such that the highest Kelvin values produce the lowest mired values. Secondly, the values skew, especially at near the lowest mired values.

Consider the following chart. The first two columns are empirical data gathered by setting a temp in Kelvins using Control Center and then retrieving the mireds value from the API.

K,    Mireds, K * O.O5, mired / 0.05, 1000000 / K
2900, 344,    145,      6880,         345
3900, 254,    195,      4880,         256
4950, 201,    247.5,    4020,         202
5950, 168,    297.5,    3360,         168
7000, 143,    350,      2860,         143